### PR TITLE
Speed-up model calculation

### DIFF
--- a/src/FlareWave.cpp
+++ b/src/FlareWave.cpp
@@ -37,7 +37,11 @@ changepoint(2,                                                         // number
            false,
            ChangepointDistribution(Data::get_instance().get_tstart(),  // the lower end of allowed change point times is the start of the data
                                    Data::get_instance().get_tend())),  // the upper end of allowed change point times is the end of the data
-mu(Data::get_instance().get_len()) // the model vector
+mu(Data::get_instance().get_len()),           // the model vector
+muwaves(Data::get_instance().get_len()),      // the sinusoidal models
+muflares(Data::get_instance().get_len()),     // the flare models
+muimpulse(Data::get_instance().get_len()),    // the impulse models
+muchangepoint(Data::get_instance().get_len()) // the background change point models
 {
 
 }
@@ -58,10 +62,11 @@ void FlareWave::from_prior(RNG& rng)
   
   changepoint.from_prior(rng);
   changepoint.consolidate_diff();
-  
+
   sigma = exp(log(1E-3) + log(1E6)*rng.rand());      // generate sigma from prior (uniform in log space between 1e-3 and 1e6)
-  background = tan(M_PI*(0.97*rng.rand() - 0.485));  // generate background from Cauchy prior distribution
-  background = exp(background);
+  //background = tan(M_PI*(0.97*rng.rand() - 0.485));  // generate background from Cauchy prior distribution
+  //background = exp(background); // this seems to also be changed in perturb function, so remove here
+  calculate_mu(); // calculate model
 }
 
 
@@ -129,6 +134,9 @@ void FlareWave::calculate_mu()
   // Get the data
   const vector<double>& t = Data::get_instance().get_t(); // times
   
+  // compute different components separately and add to main model at the end
+
+
   if (!updateWaves || background != prevbackground){
     mu.assign(Data::get_instance().get_len(),background); // allocate model vector
   }

--- a/src/FlareWave.h
+++ b/src/FlareWave.h
@@ -16,9 +16,14 @@ class FlareWave
     DNest4::RJObject<FlareDistribution> flares;            // flare distribution
     DNest4::RJObject<ImpulseDistribution> impulse;         // impulse distribution
     DNest4::RJObject<ChangepointDistribution> changepoint; // background change point distribution
+
+    std::vector<double> mu; // the model vector
     
-    double sigma; // Noise standard deviation
-    double background; // A flat background offset level
+    double sigma;          // Noise standard deviation
+    double background;     // A flat background offset level
+    double prevbackground; // The previous background value
+
+    void calculate_mu(); // calculate the model
     
   public:
     FlareWave(); // constructor

--- a/src/FlareWave.h
+++ b/src/FlareWave.h
@@ -18,7 +18,11 @@ class FlareWave
     DNest4::RJObject<ChangepointDistribution> changepoint; // background change point distribution
 
     std::vector<double> mu; // the model vector
-    
+    std::vector<double> muwaves;
+    std::vector<double> muflares;
+    std::vector<double> muimpulse;
+    std::vector<double> muchangepoint;
+
     double sigma;          // Noise standard deviation
     double background;     // A flat background offset level
     double prevbackground; // The previous background value

--- a/src/FlareWave.h
+++ b/src/FlareWave.h
@@ -23,8 +23,10 @@ class FlareWave
     std::vector<double> muimpulse;
     std::vector<double> muchangepoint;
 
+    bool firstiter;         // Set if first iteration of code
     double sigma;          // Noise standard deviation
     double background;     // A flat background offset level
+    
 
     void calculate_mu(); // calculate the model
     

--- a/src/FlareWave.h
+++ b/src/FlareWave.h
@@ -25,7 +25,6 @@ class FlareWave
 
     double sigma;          // Noise standard deviation
     double background;     // A flat background offset level
-    double prevbackground; // The previous background value
 
     void calculate_mu(); // calculate the model
     

--- a/src/example.json
+++ b/src/example.json
@@ -1,8 +1,8 @@
 {
  "SinusoidModel": {
-   "MaxSinusoids": 50
+   "MaxSinusoids": 5
  },
  "FlareModel":{
-    "MaxFlares": 50
+    "MaxFlares": 5
   }
 }


### PR DESCRIPTION
Use the current ability of RJObject to speed up the model calculation. If a particular part of the model, e.g. the flare components, has been perturbed as such to only increase the number of flares (and not change any current flares) then you should only need to add  those new flares on to a stored copy of the flare component of the model, rather than recalculating for all flares. If the number of flares has been reduced then all flares have to be recalculated. This is simple to do for the flare, sinusoid and impulse models, but not so simple for the change point model (due to the ordering of the change points), so is not implemented for change points yet (I may find a simple way to do this too).
